### PR TITLE
Upgrade dependencies and fix build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.jcabi</groupId>
     <artifactId>parent</artifactId>
-    <version>0.72.0</version>
+    <version>0.73.1</version>
   </parent>
   <groupId>com.yegor256</groupId>
   <artifactId>maybeslow</artifactId>
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
-      <version>2.0.16</version>
+      <version>2.0.17</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/yegor256/MayBeSlow.java
+++ b/src/main/java/com/yegor256/MayBeSlow.java
@@ -5,6 +5,8 @@
 package com.yegor256;
 
 import com.jcabi.log.Logger;
+import java.util.EnumMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -21,6 +23,20 @@ import org.junit.jupiter.api.extension.ExtensionContext;
  * @since 0.1.0
  */
 public final class MayBeSlow implements BeforeEachCallback, AfterEachCallback {
+
+    /**
+     * Verbs for each thread state.
+     */
+    private static final Map<Thread.State, String> VERBS = new EnumMap<>(Thread.State.class);
+
+    static {
+        MayBeSlow.VERBS.put(Thread.State.NEW, "We just started %s");
+        MayBeSlow.VERBS.put(Thread.State.RUNNABLE, "We're still running %s");
+        MayBeSlow.VERBS.put(Thread.State.BLOCKED, "We're blocked at %s");
+        MayBeSlow.VERBS.put(Thread.State.WAITING, "We're waiting at %s");
+        MayBeSlow.VERBS.put(Thread.State.TIMED_WAITING, "We're waiting at %s");
+        MayBeSlow.VERBS.put(Thread.State.TERMINATED, "The test %s is terminated");
+    }
 
     /**
      * Watcher.
@@ -66,29 +82,10 @@ public final class MayBeSlow implements BeforeEachCallback, AfterEachCallback {
      * @return Its status
      */
     private static String stateOf(final Thread thread, final String test) {
-        final String sum;
-        switch (thread.getState()) {
-            case NEW:
-                sum = String.format("We just started %s", test);
-                break;
-            case RUNNABLE:
-                sum = String.format("We're still running %s", test);
-                break;
-            case BLOCKED:
-                sum = String.format("We're blocked at %s", test);
-                break;
-            case WAITING:
-            case TIMED_WAITING:
-                sum = String.format("We're waiting at %s", test);
-                break;
-            case TERMINATED:
-                sum = String.format("The test %s is terminated", test);
-                break;
-            default:
-                sum = String.format("We're lost at %s", test);
-                break;
-        }
-        return sum;
+        return String.format(
+            MayBeSlow.VERBS.getOrDefault(thread.getState(), "We're lost at %s"),
+            test
+        );
     }
 
     /**
@@ -104,8 +101,7 @@ public final class MayBeSlow implements BeforeEachCallback, AfterEachCallback {
                 "\\[test-template-invocation:#([0-9]+)]"
             ).matcher(parts[3]);
             if (mtc.find()) {
-                final int index = Integer.parseInt(mtc.group(1));
-                test = String.format("%s[#%d]", test, index);
+                test = String.format("%s[#%d]", test, Integer.parseInt(mtc.group(1)));
             }
         }
         return test;

--- a/src/test/java/com/yegor256/MayBeSlowTest.java
+++ b/src/test/java/com/yegor256/MayBeSlowTest.java
@@ -4,6 +4,7 @@
  */
 package com.yegor256;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,14 +19,14 @@ final class MayBeSlowTest {
 
     @Test
     @ExtendWith(MayBeSlow.class)
-    void slowTest() throws InterruptedException {
-        Thread.sleep(5000L);
+    void slowTest() {
+        Assertions.assertDoesNotThrow(() -> Thread.sleep(5000L));
     }
 
     @ParameterizedTest
     @ValueSource(ints = {5, 3, 1, 7})
     @ExtendWith(MayBeSlow.class)
-    void sleepsFewSeconds(final int seconds) throws InterruptedException {
-        Thread.sleep((long) seconds * 1000L);
+    void sleepsFewSeconds(final int seconds) {
+        Assertions.assertDoesNotThrow(() -> Thread.sleep(seconds * 1000L));
     }
 }


### PR DESCRIPTION
## Summary

- Bump `com.jcabi:parent` POM `0.72.0` → `0.73.1`
- Bump `org.slf4j:slf4j-reload4j` `2.0.16` → `2.0.17`
- All other dependencies and plugins (`jcabi-log`, JUnit Jupiter, `revapi-maven-plugin`, `revapi-java`) were already at their latest stable versions; non-stable versions (e.g. JUnit `6.1.0-M1`, `slf4j 2.1.0-alpha1`) were skipped intentionally.

## Build fixes

The new parent POM ships an updated Qulice that introduced the PMD `ExhaustiveSwitchHasDefault` rule, which conflicts with Checkstyle's `MissingSwitchDefaultCheck` on the existing `switch` over `Thread.State`. To satisfy both rules without a workaround, the switch was replaced with an `EnumMap` lookup with a default fallback. Other lint fixes pulled in by the upgrade:

- Inlined the parsed parameterized-test index (`UnnecessaryLocalRule`).
- Wrapped `Thread.sleep` calls in `Assertions.assertDoesNotThrow` so the unit tests contain explicit assertions (`UnitTestShouldIncludeAssert`).
- Dropped a redundant `(long)` cast on an `int` (`UnnecessaryCast`).

## Test plan

- [x] `mvn clean install` passes (default profile)
- [x] `mvn clean install -Pqulice` passes (matches CI)
- [x] All 5 existing JUnit tests still pass

---
_Generated by [Claude Code](https://claude.ai/code/session_019JrbnYHLfgU9RdkjwnFKCq)_