### PR TITLE
#32: exclude test scope from ORT

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+# SPDX-License-Identifier: MIT
+---
+analyzer:
+  skip_excluded: true
+excludes:
+  scopes:
+    - pattern: "test"
+      reason: "TEST_DEPENDENCY_OF"
+      comment: "Test-only dependencies are not released with the library."


### PR DESCRIPTION
Closes #32.

Summary:
- Adds project-local ORT config with `analyzer.skip_excluded`.
- Excludes Maven `test` scope so inherited `log4j:log4j:1.2.17:test` is not evaluated as a released dependency.

Validation:
- `mise x java@temurin-21.0.11+10.0.LTS maven@3.9.16 -- mvn -ntp dependency:tree -Dincludes=log4j:log4j -Dstyle.color=never` -> `log4j:log4j:1.2.17:test`.
- `mise x ruby@3.3.11 -- ruby -ryaml -e "YAML.load_file('.ort.yml')"` -> passed.
- `mise x java@temurin-21.0.11+10.0.LTS maven@3.9.16 -- mvn -ntp test -Dstyle.color=never` -> BUILD SUCCESS, 5 tests.
- `mise x java@temurin-21.0.11+10.0.LTS maven@3.9.16 -- mvn --errors --batch-mode clean install -Pqulice -Dstyle.color=never` -> BUILD SUCCESS.
- `git diff --check` -> passed.
- `git diff --no-ext-diff | gitleaks stdin --no-banner --redact --exit-code 1` -> no leaks.

Limitations:
- I could not run the ORT Docker action locally because `ort` and `docker` are not installed on this machine.