### PR TITLE
fix(concurrent-bug): store watcher in ExtensionContext to fix thread reuse

### DIFF
--- a/.aidy/cache.js
+++ b/.aidy/cache.js
@@ -1,3 +1,0 @@
-{
-  "target": "yegor256/maybeslow"
-}

--- a/.aidy/cache.js
+++ b/.aidy/cache.js
@@ -1,0 +1,3 @@
+{
+  "target": "yegor256/maybeslow"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .settings
 node_modules/
 target/
+.aidy/

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
       <version>${junit.version}</version>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.yegor256</groupId>
+      <artifactId>together</artifactId>
+      <version>0.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/yegor256/MayBeSlow.java
+++ b/src/main/java/com/yegor256/MayBeSlow.java
@@ -39,15 +39,16 @@ public final class MayBeSlow implements BeforeEachCallback, AfterEachCallback {
     }
 
     /**
-     * Watcher.
+     * Store namespace.
      */
-    private Thread watch;
+    private static final ExtensionContext.Namespace NAMESPACE =
+        ExtensionContext.Namespace.create(MayBeSlow.class);
 
     @Override
     public void beforeEach(final ExtensionContext ctx) {
         final long start = System.currentTimeMillis();
         final String test = MayBeSlow.testOf(ctx);
-        this.watch = new Thread(
+        final Thread watcher = new Thread(
             () -> {
                 long cycle = 1L;
                 while (true) {
@@ -60,19 +61,20 @@ public final class MayBeSlow implements BeforeEachCallback, AfterEachCallback {
                     Logger.warn(
                         MayBeSlow.class,
                         "%s (%[ms]s), please wait...",
-                        MayBeSlow.stateOf(this.watch, test),
+                        MayBeSlow.stateOf(Thread.currentThread(), test),
                         System.currentTimeMillis() - start
                     );
                     ++cycle;
                 }
             }
         );
-        this.watch.start();
+        ctx.getStore(MayBeSlow.NAMESPACE).put("watch", watcher);
+        watcher.start();
     }
 
     @Override
     public void afterEach(final ExtensionContext ctx) {
-        this.watch.interrupt();
+        ctx.getStore(MayBeSlow.NAMESPACE).get("watch", Thread.class).interrupt();
     }
 
     /**

--- a/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
+++ b/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
@@ -4,29 +4,18 @@
  */
 package com.yegor256;
 
-import com.yegor256.Together;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Method;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.TestInstance;
-import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.TestInstances;
-import org.junit.jupiter.api.function.ThrowingConsumer;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 
 /**
  * Regression test for the thread-reuse bug: MayBeSlow throws
  * IllegalThreadStateException when beforeEach is called concurrently from
  * multiple threads, because the shared {@code watch} field is assigned and
  * started in two separate, non-atomic steps.
+ *
+ * @since 0.2.0
  */
 final class MayBeSlowConcurrencyTest {
 
@@ -34,147 +23,16 @@ final class MayBeSlowConcurrencyTest {
     @Disabled("Reproduces the bug: Thread watch field is not safe for concurrent beforeEach calls")
     void doesNotThrowWhenCalledConcurrently() throws Exception {
         final MayBeSlow extension = new MayBeSlow();
-        new Together<>(
-            50,
-            thread -> {
-                final ExtensionContext ctx = new StubExtensionContext();
-                extension.beforeEach(ctx);
-                extension.afterEach(ctx);
-                return true;
-            }
-        ).asList();
-    }
-
-    /**
-     * Minimal stub that satisfies the two methods MayBeSlow.beforeEach
-     * actually calls: getTestMethod() and getUniqueId().
-     */
-    @SuppressWarnings("PMD.TooManyMethods")
-    private static final class StubExtensionContext implements ExtensionContext {
-
-        @Override
-        public Optional<ExtensionContext> getParent() {
-            return Optional.empty();
-        }
-
-        @Override
-        public ExtensionContext getRoot() {
-            return this;
-        }
-
-        @Override
-        public String getUniqueId() {
-            return "stub/[1]";
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "stub";
-        }
-
-        @Override
-        public Set<String> getTags() {
-            return Set.of();
-        }
-
-        @Override
-        public Optional<AnnotatedElement> getElement() {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Class<?>> getTestClass() {
-            return Optional.empty();
-        }
-
-        @Override
-        public List<Class<?>> getEnclosingTestClasses() {
-            return List.of();
-        }
-
-        @Override
-        public Optional<TestInstance.Lifecycle> getTestInstanceLifecycle() {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Object> getTestInstance() {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<TestInstances> getTestInstances() {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<Method> getTestMethod() {
-            try {
-                return Optional.of(
-                    MayBeSlowConcurrencyTest.class.getDeclaredMethod(
-                        "doesNotThrowWhenCalledConcurrently"
-                    )
-                );
-            } catch (final NoSuchMethodException ex) {
-                throw new IllegalStateException(ex);
-            }
-        }
-
-        @Override
-        public Optional<Throwable> getExecutionException() {
-            return Optional.empty();
-        }
-
-        @Override
-        public Optional<String> getConfigurationParameter(final String key) {
-            return Optional.empty();
-        }
-
-        @Override
-        public <T> Optional<T> getConfigurationParameter(
-            final String key,
-            final Function<? super String, ? extends T> transformer
-        ) {
-            return Optional.empty();
-        }
-
-        @Override
-        public void publishReportEntry(final Map<String, String> map) {
-        }
-
-        @Override
-        public void publishFile(
-            final String name,
-            final org.junit.jupiter.api.MediaType type,
-            final ThrowingConsumer<Path> action
-        ) {
-        }
-
-        @Override
-        public void publishDirectory(
-            final String name,
-            final ThrowingConsumer<Path> action
-        ) {
-        }
-
-        @Override
-        public Store getStore(final Namespace namespace) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public Store getStore(final StoreScope scope, final Namespace namespace) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public ExecutionMode getExecutionMode() {
-            return ExecutionMode.CONCURRENT;
-        }
-
-        @Override
-        public ExecutableInvoker getExecutableInvoker() {
-            throw new UnsupportedOperationException();
-        }
+        Assertions.assertFalse(
+            new Together<>(
+                50,
+                thread -> {
+                    final ExtensionContext ctx = new StubExtensionContext();
+                    extension.beforeEach(ctx);
+                    extension.afterEach(ctx);
+                    return true;
+                }
+            ).asList().isEmpty()
+        );
     }
 }

--- a/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
+++ b/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
@@ -4,6 +4,7 @@
  */
 package com.yegor256;
 
+import com.yegor256.Together;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.nio.file.Path;
@@ -11,10 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -35,38 +33,18 @@ final class MayBeSlowConcurrencyTest {
     @Test
     @Disabled("Reproduces the bug: Thread watch field is not safe for concurrent beforeEach calls")
     void doesNotThrowWhenCalledConcurrently() throws Exception {
-        final int threads = 50;
-        final int rounds = 20;
-        final AtomicReference<Throwable> caught = new AtomicReference<>();
-        for (int round = 0; round < rounds && caught.get() == null; ++round) {
+        for (int round = 0; round < 20; round++) {
             final MayBeSlow extension = new MayBeSlow();
-            final CyclicBarrier barrier = new CyclicBarrier(threads);
-            final Thread[] workers = new Thread[threads];
-            for (int idx = 0; idx < threads; idx++) {
-                workers[idx] = new Thread(
-                    () -> {
-                        try {
-                            barrier.await();
-                            final ExtensionContext ctx = new StubExtensionContext();
-                            extension.beforeEach(ctx);
-                            extension.afterEach(ctx);
-                        } catch (final IllegalThreadStateException ex) {
-                            caught.compareAndSet(null, ex);
-                        } catch (final Exception ex) {
-                            // CyclicBarrier / other JUnit internals — not the bug
-                        }
-                    }
-                );
-                workers[idx].start();
-            }
-            for (final Thread worker : workers) {
-                worker.join(5_000L);
-            }
+            new Together<>(
+                50,
+                thread -> {
+                    final ExtensionContext ctx = new StubExtensionContext();
+                    extension.beforeEach(ctx);
+                    extension.afterEach(ctx);
+                    return true;
+                }
+            ).asList();
         }
-        Assertions.assertNull(
-            caught.get(),
-            "MayBeSlow threw IllegalThreadStateException when beforeEach was called concurrently — the Thread watch field is not safe for parallel use"
-        );
     }
 
     /**

--- a/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
+++ b/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExecutableInvoker;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -30,21 +30,19 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
  */
 final class MayBeSlowConcurrencyTest {
 
-    @Test
+    @RepeatedTest(20)
     @Disabled("Reproduces the bug: Thread watch field is not safe for concurrent beforeEach calls")
     void doesNotThrowWhenCalledConcurrently() throws Exception {
-        for (int round = 0; round < 20; round++) {
-            final MayBeSlow extension = new MayBeSlow();
-            new Together<>(
-                50,
-                thread -> {
-                    final ExtensionContext ctx = new StubExtensionContext();
-                    extension.beforeEach(ctx);
-                    extension.afterEach(ctx);
-                    return true;
-                }
-            ).asList();
-        }
+        final MayBeSlow extension = new MayBeSlow();
+        new Together<>(
+            50,
+            thread -> {
+                final ExtensionContext ctx = new StubExtensionContext();
+                extension.beforeEach(ctx);
+                extension.afterEach(ctx);
+                return true;
+            }
+        ).asList();
     }
 
     /**

--- a/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
+++ b/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
@@ -1,0 +1,204 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExecutableInvoker;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstances;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * Regression test for the thread-reuse bug: MayBeSlow throws
+ * IllegalThreadStateException when beforeEach is called concurrently from
+ * multiple threads, because the shared {@code watch} field is assigned and
+ * started in two separate, non-atomic steps.
+ */
+final class MayBeSlowConcurrencyTest {
+
+    @Test
+    @Disabled("Reproduces the bug: Thread watch field is not safe for concurrent beforeEach calls")
+    void doesNotThrowWhenCalledConcurrently() throws Exception {
+        final int threads = 50;
+        final int rounds = 20;
+        final AtomicReference<Throwable> caught = new AtomicReference<>();
+        for (int round = 0; round < rounds && caught.get() == null; ++round) {
+            final MayBeSlow extension = new MayBeSlow();
+            final CyclicBarrier barrier = new CyclicBarrier(threads);
+            final Thread[] workers = new Thread[threads];
+            for (int idx = 0; idx < threads; idx++) {
+                workers[idx] = new Thread(
+                    () -> {
+                        try {
+                            barrier.await();
+                            final ExtensionContext ctx = new StubExtensionContext();
+                            extension.beforeEach(ctx);
+                            extension.afterEach(ctx);
+                        } catch (final IllegalThreadStateException ex) {
+                            caught.compareAndSet(null, ex);
+                        } catch (final Exception ex) {
+                            // CyclicBarrier / other JUnit internals — not the bug
+                        }
+                    }
+                );
+                workers[idx].start();
+            }
+            for (final Thread worker : workers) {
+                worker.join(5_000L);
+            }
+        }
+        Assertions.assertNull(
+            caught.get(),
+            "MayBeSlow threw IllegalThreadStateException when beforeEach was called concurrently — the Thread watch field is not safe for parallel use"
+        );
+    }
+
+    /**
+     * Minimal stub that satisfies the two methods MayBeSlow.beforeEach
+     * actually calls: getTestMethod() and getUniqueId().
+     */
+    @SuppressWarnings("PMD.TooManyMethods")
+    private static final class StubExtensionContext implements ExtensionContext {
+
+        @Override
+        public Optional<ExtensionContext> getParent() {
+            return Optional.empty();
+        }
+
+        @Override
+        public ExtensionContext getRoot() {
+            return this;
+        }
+
+        @Override
+        public String getUniqueId() {
+            return "stub/[1]";
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "stub";
+        }
+
+        @Override
+        public Set<String> getTags() {
+            return Set.of();
+        }
+
+        @Override
+        public Optional<AnnotatedElement> getElement() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Class<?>> getTestClass() {
+            return Optional.empty();
+        }
+
+        @Override
+        public List<Class<?>> getEnclosingTestClasses() {
+            return List.of();
+        }
+
+        @Override
+        public Optional<TestInstance.Lifecycle> getTestInstanceLifecycle() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Object> getTestInstance() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<TestInstances> getTestInstances() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<Method> getTestMethod() {
+            try {
+                return Optional.of(
+                    MayBeSlowConcurrencyTest.class.getDeclaredMethod(
+                        "doesNotThrowWhenCalledConcurrently"
+                    )
+                );
+            } catch (final NoSuchMethodException ex) {
+                throw new IllegalStateException(ex);
+            }
+        }
+
+        @Override
+        public Optional<Throwable> getExecutionException() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Optional<String> getConfigurationParameter(final String key) {
+            return Optional.empty();
+        }
+
+        @Override
+        public <T> Optional<T> getConfigurationParameter(
+            final String key,
+            final Function<? super String, ? extends T> transformer
+        ) {
+            return Optional.empty();
+        }
+
+        @Override
+        public void publishReportEntry(final Map<String, String> map) {
+        }
+
+        @Override
+        public void publishFile(
+            final String name,
+            final org.junit.jupiter.api.MediaType type,
+            final ThrowingConsumer<Path> action
+        ) {
+        }
+
+        @Override
+        public void publishDirectory(
+            final String name,
+            final ThrowingConsumer<Path> action
+        ) {
+        }
+
+        @Override
+        public Store getStore(final Namespace namespace) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Store getStore(final StoreScope scope, final Namespace namespace) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ExecutionMode getExecutionMode() {
+            return ExecutionMode.CONCURRENT;
+        }
+
+        @Override
+        public ExecutableInvoker getExecutableInvoker() {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
+++ b/src/test/java/com/yegor256/MayBeSlowConcurrencyTest.java
@@ -5,7 +5,6 @@
 package com.yegor256;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
@@ -20,7 +19,6 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 final class MayBeSlowConcurrencyTest {
 
     @RepeatedTest(20)
-    @Disabled("Reproduces the bug: Thread watch field is not safe for concurrent beforeEach calls")
     void doesNotThrowWhenCalledConcurrently() throws Exception {
         final MayBeSlow extension = new MayBeSlow();
         Assertions.assertFalse(

--- a/src/test/java/com/yegor256/StubExtensionContext.java
+++ b/src/test/java/com/yegor256/StubExtensionContext.java
@@ -1,0 +1,158 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256;
+
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExecutableInvoker;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestInstances;
+import org.junit.jupiter.api.function.ThrowingConsumer;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+/**
+ * Minimal stub that satisfies the two methods MayBeSlow.beforeEach
+ * actually calls: getTestMethod() and getUniqueId().
+ *
+ * @since 0.2.0
+ */
+@SuppressWarnings("PMD.CouplingBetweenObjects")
+final class StubExtensionContext implements ExtensionContext {
+
+    @Override
+    public Optional<ExtensionContext> getParent() {
+        return Optional.empty();
+    }
+
+    @Override
+    public ExtensionContext getRoot() {
+        return this;
+    }
+
+    @Override
+    public String getUniqueId() {
+        return "stub/[1]";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "stub";
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return Set.of();
+    }
+
+    @Override
+    public Optional<AnnotatedElement> getElement() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Class<?>> getTestClass() {
+        return Optional.empty();
+    }
+
+    @Override
+    public List<Class<?>> getEnclosingTestClasses() {
+        return List.of();
+    }
+
+    @Override
+    public Optional<TestInstance.Lifecycle> getTestInstanceLifecycle() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Object> getTestInstance() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<TestInstances> getTestInstances() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Method> getTestMethod() {
+        try {
+            return Optional.of(
+                MayBeSlowConcurrencyTest.class.getDeclaredMethod(
+                    "doesNotThrowWhenCalledConcurrently"
+                )
+            );
+        } catch (final NoSuchMethodException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Override
+    public Optional<Throwable> getExecutionException() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<String> getConfigurationParameter(final String key) {
+        return Optional.empty();
+    }
+
+    @Override
+    public <T> Optional<T> getConfigurationParameter(
+        final String key,
+        final Function<? super String, ? extends T> transformer
+    ) {
+        return Optional.empty();
+    }
+
+    @Override
+    public void publishReportEntry(final Map<String, String> map) {
+        // nothing to publish in stub
+    }
+
+    @Override
+    public void publishFile(
+        final String name,
+        final org.junit.jupiter.api.MediaType type,
+        final ThrowingConsumer<Path> action
+    ) {
+        // nothing to publish in stub
+    }
+
+    @Override
+    public void publishDirectory(
+        final String name,
+        final ThrowingConsumer<Path> action
+    ) {
+        // nothing to publish in stub
+    }
+
+    @Override
+    public Store getStore(final Namespace namespace) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Store getStore(final StoreScope scope, final Namespace namespace) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ExecutionMode getExecutionMode() {
+        return ExecutionMode.CONCURRENT;
+    }
+
+    @Override
+    public ExecutableInvoker getExecutableInvoker() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/com/yegor256/StubExtensionContext.java
+++ b/src/test/java/com/yegor256/StubExtensionContext.java
@@ -28,6 +28,11 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 final class StubExtensionContext implements ExtensionContext {
 
+    /**
+     * Store for this context.
+     */
+    private final Store store = new ThreadStore();
+
     @Override
     public Optional<ExtensionContext> getParent() {
         return Optional.empty();
@@ -138,12 +143,12 @@ final class StubExtensionContext implements ExtensionContext {
 
     @Override
     public Store getStore(final Namespace namespace) {
-        throw new UnsupportedOperationException();
+        return this.store;
     }
 
     @Override
     public Store getStore(final StoreScope scope, final Namespace namespace) {
-        throw new UnsupportedOperationException();
+        return this.store;
     }
 
     @Override

--- a/src/test/java/com/yegor256/ThreadStore.java
+++ b/src/test/java/com/yegor256/ThreadStore.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2024-2026 Yegor Bugayenko
+ * SPDX-License-Identifier: MIT
+ */
+package com.yegor256;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * In-memory {@link ExtensionContext.Store} backed by a {@link ConcurrentHashMap}.
+ *
+ * @since 0.2.0
+ */
+final class ThreadStore implements ExtensionContext.Store {
+
+    /**
+     * Backing storage.
+     */
+    private final Map<Object, Object> data = new ConcurrentHashMap<>();
+
+    @Override
+    public Object get(final Object key) {
+        return this.data.get(key);
+    }
+
+    @Override
+    public <V> V get(final Object key, final Class<V> type) {
+        return type.cast(this.data.get(key));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public <K, V> Object getOrComputeIfAbsent(
+        final K key,
+        final Function<? super K, ? extends V> creator
+    ) {
+        return this.data.computeIfAbsent(key, ignored -> creator.apply(key));
+    }
+
+    @Override
+    public <K, V> Object computeIfAbsent(
+        final K key,
+        final Function<? super K, ? extends V> creator
+    ) {
+        return this.data.computeIfAbsent(key, ignored -> creator.apply(key));
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public <K, V> V getOrComputeIfAbsent(
+        final K key,
+        final Function<? super K, ? extends V> creator,
+        final Class<V> type
+    ) {
+        return type.cast(this.data.computeIfAbsent(key, ignored -> creator.apply(key)));
+    }
+
+    @Override
+    public <K, V> V computeIfAbsent(
+        final K key,
+        final Function<? super K, ? extends V> creator,
+        final Class<V> type
+    ) {
+        return type.cast(this.data.computeIfAbsent(key, ignored -> creator.apply(key)));
+    }
+
+    @Override
+    public void put(final Object key, final Object value) {
+        this.data.put(key, value);
+    }
+
+    @Override
+    public Object remove(final Object key) {
+        return this.data.remove(key);
+    }
+
+    @Override
+    public <V> V remove(final Object key, final Class<V> type) {
+        return type.cast(this.data.remove(key));
+    }
+}


### PR DESCRIPTION
Fixes a concurrency bug in `MayBeSlow` where a shared `watch` field caused `IllegalThreadStateException` under parallel test execution; watcher state is now stored per-context via `ExtensionContext.Store`.

Fixes concurrent-bug